### PR TITLE
Fixes the Command for macOS drive recovery

### DIFF
--- a/docs/USER-DOCUMENTATION.md
+++ b/docs/USER-DOCUMENTATION.md
@@ -166,7 +166,7 @@ Run the following command in `Terminal.app`, replacing `N` by the corresponding
 disk number, which you can find by running `diskutil list`:
 
 ```sh
-diskutil eraseDisk free UNTITLED /dev/diskN
+diskutil eraseDisk FAT32 UNTITLED MBRFormat /dev/diskN
 ```
 
 ### GNU/Linux


### PR DESCRIPTION
Changes the documentation to update the disktutil command which didn't fix my case, cause the boot partition was broken.
This way it rewrites the drive into a FAT32 partition editable in Unix/Windows.